### PR TITLE
Behat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ If you are using self signed certificates, phantomjs must be started as follows:
 phantomjs --webdriver=8643 --debug=true --ssl-protocol=any --ignore-ssl-errors=true
 ```
 
+Prophet provides a ProphetContext class that inherits from MinkContext and adds
+additional useful step definitions. It is highly recommended to make your FeatureContext
+files inherit from this.  It also provides a post-step hook that will automatically
+take a screenshot if a step fails.
+
 ## Author
 
 [Samuel Schmidt](https://github.com/dersam)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Prophet must be executed from the command line at the Magento root.
 
 `prophet scry:phpunit`: Same as the basic `prophet` invocation.
 
+`prophet scry:behat`: Run functional tests using Behat. Requires phantomjs and selenium-server.
+
 `prophet scry:barista`: (experimental) Run javascript acceptance tests using mocha and zombie. Requires mocha and zombie to be installed globally.
 
 `prophet help [command]`: View help for a specific command.
@@ -164,6 +166,16 @@ public function testRecentAction()
 }
 ```
 
+## Behat
+
+Prophet can run functional tests using Behat and Mink. The default configuration from init will use
+PhantomJS and Selenium-Server, which must be installed separately.
+
+If you are using self signed certificates, phantomjs must be started as follows:
+
+```
+phantomjs --webdriver=8643 --debug=true --ssl-protocol=any --ignore-ssl-errors=true
+```
 
 ## Author
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "linusshops/prophet",
   "description": "Zero footprint Module testing for Magento Modules",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "utility",
   "keywords": [
     "magento",
@@ -35,7 +35,10 @@
     "symfony/console": "~2.6",
     "symfony/event-dispatcher":"~2.7",
     "phpunit/phpunit": "^4.6.4",
-    "psy/psysh":"~0.4@stable"
+    "psy/psysh":"~0.4@stable",
+    "behat/behat": "~3",
+    "behat/mink-selenium2-driver":"~1",
+    "behat/mink-zombie-driver": "^1.3"
   },
   "bin": [
     "prophet"

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,9 @@
     "psy/psysh":"~0.4@stable",
     "behat/behat": "~3",
     "behat/mink-selenium2-driver":"~1",
-    "behat/mink-zombie-driver": "^1.3",
-    "behat/mink-extension": "^2.1"
+    "behat/mink-extension": "^2.1",
+    "behat/mink-goutte-driver": "^1.2",
+    "behat/mink": "^1.7"
   },
   "bin": [
     "prophet"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "psy/psysh":"~0.4@stable",
     "behat/behat": "~3",
     "behat/mink-selenium2-driver":"~1",
-    "behat/mink-zombie-driver": "^1.3"
+    "behat/mink-zombie-driver": "^1.3",
+    "behat/mink-extension": "^2.1"
   },
   "bin": [
     "prophet"

--- a/prophet
+++ b/prophet
@@ -45,12 +45,13 @@ use Symfony\Component\Console\Application;
 $application = new Application();
 
 $application->setName('Prophet');
-$application->setVersion('0.5.1');
+$application->setVersion('0.6.0');
 $application->setDefaultCommand('scry:phpunit');
 
 \LinusShops\Prophet\ConfigRepository::setProphetPath($_SERVER['argv'][0]);
 
 $application->add(new LinusShops\Prophet\Commands\Scry\PhpUnit());
+$application->add(new LinusShops\Prophet\Commands\Scry\Behat());
 $application->add(new LinusShops\Prophet\Commands\Scry\Barista());
 $application->add(new LinusShops\Prophet\Commands\Validate());
 $application->add(new LinusShops\Prophet\Commands\Analyze());

--- a/src/LinusShops/Prophet/Adapters/Behat/ProphetInput.php
+++ b/src/LinusShops/Prophet/Adapters/Behat/ProphetInput.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ *
+ *
+ * @author Sam Schmidt <samuel@dersam.net>
+ * @date 2015-10-15
+ * @company Linus Shops
+ */
+
+namespace LinusShops\Prophet\Adapters\Behat;
+
+
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ProphetInput extends ArrayInput
+{
+}

--- a/src/LinusShops/Prophet/Commands/Scry/Barista.php
+++ b/src/LinusShops/Prophet/Commands/Scry/Barista.php
@@ -23,7 +23,7 @@ class Barista extends Scry
 
         $this
             ->setName('scry:barista')
-            ->setDescription('Run mocha zombie tests for modules in prophet.json')
+            ->setDescription('Run mocha+zombie tests for modules in prophet.json')
         ;
     }
 

--- a/src/LinusShops/Prophet/Commands/Scry/Behat.php
+++ b/src/LinusShops/Prophet/Commands/Scry/Behat.php
@@ -61,7 +61,7 @@ class Behat extends Scry
     public function checkProcess($name)
     {
         $running = false;
-        exec("pgrep {$name}", $output, $return);
+        exec("pgrep -f {$name}", $output, $return);
         if ($return == 0) {
             $running = true;
         }

--- a/src/LinusShops/Prophet/Commands/Scry/Behat.php
+++ b/src/LinusShops/Prophet/Commands/Scry/Behat.php
@@ -13,6 +13,7 @@ namespace LinusShops\Prophet\Commands\Scry;
 use Behat\Behat\ApplicationFactory;
 use LinusShops\Prophet\Adapters\Behat\ProphetInput;
 use LinusShops\Prophet\Commands\Scry;
+use LinusShops\Prophet\ConsoleHelper;
 use LinusShops\Prophet\Module;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -35,12 +36,36 @@ class Behat extends Scry
         InputInterface $input,
         OutputInterface $output
     ) {
+        $cli = new ConsoleHelper();
         chdir($module->getPath());
+
+        //Confirm phantomjs and selenium server are running
+        if (!$this->checkProcess('phantomjs')) {
+            $cli->write('<error>phantomjs not running, exiting.</error>', $output);
+            return;
+        }
+
+        if (!$this->checkProcess('selenium-server')) {
+            $cli->write('<error>selenium-server not running, exiting.</error>', $output);
+            return;
+        }
+
         //Instantiate behat with a custom console Input to
         //avoid pollution from Prophet's cli input.
         $input = new ProphetInput(array());
 
         $factory = new ApplicationFactory();
         $factory->createApplication()->run($input);
+    }
+
+    public function checkProcess($name)
+    {
+        $running = false;
+        exec("pgrep {$name}", $output, $return);
+        if ($return == 0) {
+            $running = true;
+        }
+
+        return $running;
     }
 }

--- a/src/LinusShops/Prophet/Commands/Scry/Behat.php
+++ b/src/LinusShops/Prophet/Commands/Scry/Behat.php
@@ -10,6 +10,8 @@
 namespace LinusShops\Prophet\Commands\Scry;
 
 
+use Behat\Behat\ApplicationFactory;
+use LinusShops\Prophet\Adapters\Behat\ProphetInput;
 use LinusShops\Prophet\Commands\Scry;
 use LinusShops\Prophet\Module;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,6 +35,12 @@ class Behat extends Scry
         InputInterface $input,
         OutputInterface $output
     ) {
-        // TODO: Implement doTest() method.
+        chdir($module->getPath());
+        //Instantiate behat with a faked InputInterface to
+        //avoid pollution from Prophet's cli input.
+        $input = new ProphetInput();
+
+        $factory = new ApplicationFactory();
+        $factory->createApplication()->run($input);
     }
 }

--- a/src/LinusShops/Prophet/Commands/Scry/Behat.php
+++ b/src/LinusShops/Prophet/Commands/Scry/Behat.php
@@ -36,9 +36,9 @@ class Behat extends Scry
         OutputInterface $output
     ) {
         chdir($module->getPath());
-        //Instantiate behat with a faked InputInterface to
+        //Instantiate behat with a custom console Input to
         //avoid pollution from Prophet's cli input.
-        $input = new ProphetInput();
+        $input = new ProphetInput(array());
 
         $factory = new ApplicationFactory();
         $factory->createApplication()->run($input);

--- a/src/LinusShops/Prophet/Commands/Scry/Behat.php
+++ b/src/LinusShops/Prophet/Commands/Scry/Behat.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ *
+ *
+ * @author Sam Schmidt <samuel@dersam.net>
+ * @date 2015-10-15
+ * @company Linus Shops
+ */
+
+namespace LinusShops\Prophet\Commands\Scry;
+
+
+use LinusShops\Prophet\Commands\Scry;
+use LinusShops\Prophet\Module;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Behat extends Scry
+{
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('scry:behat')
+            ->setDescription('Run behat tests for modules in prophet.json')
+        ;
+    }
+
+    public function doTest(
+        Module $module,
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        // TODO: Implement doTest() method.
+    }
+}

--- a/src/LinusShops/Prophet/Context/ProphetContext.php
+++ b/src/LinusShops/Prophet/Context/ProphetContext.php
@@ -14,6 +14,8 @@ namespace LinusShops\Prophet\Context;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\WebAssert;
 use Behat\MinkExtension\Context\MinkContext;
 use Behat\Testwork\Tester\Result\TestResult;
 
@@ -67,5 +69,33 @@ class ProphetContext extends MinkContext
     public function setViewportSize($width, $height)
     {
         $this->getSession()->getDriver()->resizeWindow($width, $height);
+    }
+
+    /**
+     * @Given /^I wait "([^"]*)" seconds$/
+     */
+    public function iWaitSeconds($seconds)
+    {
+        sleep($seconds);
+    }
+
+    /**
+     * @Given /^I wait until selector "([^"]*)" exists$/
+     */
+    public function iWaitUntilISee($selector)
+    {
+        /** @var $context ProphetContext */
+        $this->waitFor(function($context) use ($selector)
+        {
+            /** @var WebAssert $session */
+            $session = $context->assertSession();
+            try {
+                $session->elementExists('css', $selector, $context->getSession()->getPage());
+            } catch (ElementNotFoundException $e) {
+                return false;
+            }
+
+            return true;
+        }, 10);
     }
 }

--- a/src/LinusShops/Prophet/Context/ProphetContext.php
+++ b/src/LinusShops/Prophet/Context/ProphetContext.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Provides additional context helpers when using Mink in Behat via Prophet
+ *
+ * Your feature contexts should extend this.
+ *
+ * @author Sam Schmidt <samuel@dersam.net>
+ * @date 2015-10-15
+ * @company Linus Shops
+ */
+
+namespace LinusShops\Prophet\Context;
+
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Mink\Driver\Selenium2Driver;
+use Behat\MinkExtension\Context\MinkContext;
+use Behat\Testwork\Tester\Result\TestResult;
+
+class ProphetContext extends MinkContext
+{
+    public function waitFor ($lambda, $wait = 60)
+    {
+        for ($i = 0; $i < $wait; $i++)
+        {
+            try {
+                if ($lambda($this)) {
+                    return true;
+                }
+            } catch (Exception $e) {
+                // do nothing
+            }
+
+            sleep(1);
+        }
+
+        throw new Exception(
+            "Step timed out after $wait seconds"
+        );
+    }
+
+    /**
+     * https://blogs.library.ucsf.edu/ckm/2014/05/14/see-your-failures-taking-screenshots-with-phantomjs-running-behat-tests/
+     * @AfterStep
+     * @param AfterStepScope $event
+     */
+    public function takeScreenshotAfterFailedStep(AfterStepScope $event)
+    {
+        $result = $event->getTestResult();
+        if (!$result->isPassed()) {
+            if ($this->getSession()->getDriver() instanceof Selenium2Driver) {
+                $stepText = $event->getStep()->getText();
+                $fileTitle = preg_replace("#[^a-zA-Z0-9\._-]#", '', $stepText);
+                $fileName = '/tmp' . DIRECTORY_SEPARATOR . $fileTitle . '.png';
+                $screenshot = $this->getSession()->getDriver()->getScreenshot();
+                file_put_contents($fileName, $screenshot);
+                print "Screenshot for '{$stepText}' placed in {$fileName}\n";
+            }
+        }
+    }
+
+    /**
+     * Set the size of the window
+     *
+     * @Given /^the viewport has width "(?P<width>[^"]+)" and height "(?P<height>[^"]+)"$/
+     */
+    public function setViewportSize($width, $height)
+    {
+        $this->getSession()->getDriver()->resizeWindow($width, $height);
+    }
+}

--- a/src/LinusShops/Prophet/Module.php
+++ b/src/LinusShops/Prophet/Module.php
@@ -101,10 +101,13 @@ class Module
     public function createTestStructure($pathPrefix = '.')
     {
         file_put_contents($this->getPhpUnitPath($pathPrefix), $this->getPhpunitStandardXml());
+        file_put_contents($this->getBehatPath($pathPrefix), $this->getBehatStandardConfig());
 
         //Create tests directory
         if (!file_exists($pathPrefix.'/'.$this->getPath())) {
             mkdir($pathPrefix.'/'.$this->getPath().'/tests');
+            mkdir($pathPrefix.'/'.$this->getPath().'/tests/phpunit');
+            mkdir($pathPrefix.'/'.$this->getPath().'/tests/behat');
         }
 
     }
@@ -112,6 +115,11 @@ class Module
     public function getPhpUnitPath($pathPrefix = '.')
     {
         return $pathPrefix.'/'.$this->getPath().'/phpunit.xml';
+    }
+
+    public function getBehatPath($pathPrefix = '.')
+    {
+        return $pathPrefix.'/'.$this->getPath().'/behat.yml';
     }
 
     public function getPhpunitStandardXml()
@@ -134,6 +142,34 @@ class Module
 </phpunit>
 
 XML;
+
+    }
+
+    public function getBehatStandardConfig()
+    {
+        return <<<YML
+# behat.yml
+
+default:
+    autoload:
+        '': %paths.base%/tests/behat/contexts
+    suites:
+        default:
+          paths: [ %paths.base%/tests/behat ]
+          contexts:
+            - FeatureContext
+            - Behat\MinkExtension\Context\MinkContext
+    extensions:
+        Behat\MinkExtension:
+            base_url: https://develop.vagrant.dev
+            sessions:
+                headless:
+                    selenium2:
+                      wd_host: "http://localhost:8643/wd/hub"
+                full:
+                    selenium2: ~
+
+YML;
 
     }
 }


### PR DESCRIPTION
Close #4 - Implements a basic Behat integration (`prophet scry:behat`). The standard config provided by Init will expect phantomjs and selenium-server to be installed on the machine.

Future enhancements: 
* allow configuration of phantomjs port (currently hardcoded to 8643)
* add support for goutte driver- encountered some weird issues with self-signed certs